### PR TITLE
fix: change sockets namespaces

### DIFF
--- a/src/utils/hooks/useChatSocket.ts
+++ b/src/utils/hooks/useChatSocket.ts
@@ -9,7 +9,7 @@ export const useChatSocket = () => {
   const [socket, setSocket] = useState<Socket | null>(null)
   const [chatId, setChatId] = useState<string | null>(null)
 
-  const URL = import.meta.env.VITE_APP_BASE_URL
+  const URL = `${import.meta.env.VITE_APP_BASE_URL}/private-chats`
   const userId = Cookies.get('userId')
   const recipientId = recipient?.id
 

--- a/src/utils/hooks/useGroupChatSocket.ts
+++ b/src/utils/hooks/useGroupChatSocket.ts
@@ -10,7 +10,7 @@ export const useGroupChatSocket = () => {
   const { recipientGroup, setGroupMessages } = useContext(ChatContext)
   const [socket, setSocket] = useState<Socket | null>(null)
 
-  const URL = `${import.meta.env.VITE_APP_BASE_URL}/grupos`
+  const URL = `${import.meta.env.VITE_APP_BASE_URL}/group-chats`
   const userId = Cookies.get('userId')
   const recipientGroupId = recipientGroup?.id
 


### PR DESCRIPTION
Change socket connection name spaces to adapt to changes made in the API.